### PR TITLE
Remove select duplication

### DIFF
--- a/jquery.kladr.js
+++ b/jquery.kladr.js
@@ -413,7 +413,6 @@
             function mouseselect() {
                 var a = $(this);
                 if(a.is('li')) a = a.find('a');
-                select(a);
                 close();
                 input.focus();
                 return false;


### PR DESCRIPTION
Event 'Select' is firing twice on mouse select. It seems that line 416 is left of the old code. Actual 'select' can be found in the 'close' function.
