### PR TITLE
Update jquery.kladr.js

### DIFF
--- a/jquery.kladr.js
+++ b/jquery.kladr.js
@@ -459,6 +459,13 @@
                 var strNew = '';
                 var ch;
                 var index;
+                var length = val.length;
+                
+                if ( val[ length - 1 ] === '.' )
+                {
+                    length--;
+                }
+                
                 for( var i=0; i<val.length; i++ ){
                     ch = val[i];                    
                     index = en.indexOf(ch);


### PR DESCRIPTION
Баг при транслитерации адресов вроде "Предтеченский Верхн.", ИМХО лучше реализовать через подсчет процента символов, чем прямым замещением.
